### PR TITLE
feat(v2): header forensics + BEC detection + extra threat feeds + MITRE ATT&CK mapping

### DIFF
--- a/backend/app/api/v1/endpoints/forensics.py
+++ b/backend/app/api/v1/endpoints/forensics.py
@@ -1,0 +1,84 @@
+"""Advanced email-forensics endpoints — header analysis + BEC detection.
+
+Exposes the new v2 services as a simple POST endpoint so the frontend
+dashboard (or external clients / SIEM) can get structured forensic
+reports on any raw email.
+"""
+
+from __future__ import annotations
+
+from email import message_from_string
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.services.bec_detector import detect_bec
+from app.services.header_forensics import analyze_message
+from app.services.mitre_mapping import coverage_matrix, map_signal_to_techniques
+
+router = APIRouter(prefix="/forensics", tags=["forensics"])
+
+
+class RawEmailRequest(BaseModel):
+    raw_email: str = Field(..., description="Full RFC 5322 email including headers and body.")
+    protected_domains: list[str] = Field(
+        default_factory=list,
+        description="Your organisation's domains — BEC lookalike detection compares against these.",
+    )
+    known_senders: list[str] = Field(
+        default_factory=list,
+        description="Previously-seen sender addresses — used for first-time-sender signalling.",
+    )
+
+
+class ForensicsResponse(BaseModel):
+    header_forensics: dict[str, Any]
+    bec: dict[str, Any]
+    mitre_techniques: list[str]
+    risk_score: float
+
+
+@router.post("/analyze", response_model=ForensicsResponse)
+async def analyze_email(payload: RawEmailRequest) -> ForensicsResponse:
+    try:
+        msg = message_from_string(payload.raw_email)
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(400, f"Malformed email: {exc}") from exc
+
+    header_report = analyze_message(msg)
+    bec_report = detect_bec(
+        msg,
+        known_senders=payload.known_senders,
+        protected_domains=payload.protected_domains,
+    )
+
+    # Map every signal to ATT&CK techniques
+    techniques: set[str] = set()
+    for sig in bec_report.signals:
+        techniques.update(map_signal_to_techniques(sig.code))
+    if header_report.spf_pass is False:
+        techniques.update(map_signal_to_techniques("spf_fail"))
+    if header_report.dkim_pass is False:
+        techniques.update(map_signal_to_techniques("dkim_fail"))
+    if header_report.dmarc_pass is False:
+        techniques.update(map_signal_to_techniques("dmarc_fail"))
+
+    # Risk score combines both sub-scores (capped at 1.0)
+    combined_risk = min(
+        0.6 * header_report.risk_score + 0.6 * bec_report.risk_score,
+        1.0,
+    )
+
+    return ForensicsResponse(
+        header_forensics=header_report.to_dict(),
+        bec=bec_report.to_dict(),
+        mitre_techniques=sorted(techniques),
+        risk_score=round(combined_risk, 3),
+    )
+
+
+@router.get("/mitre/coverage")
+async def mitre_coverage() -> dict[str, Any]:
+    """List every ATT&CK technique this service can potentially tag."""
+    return {"techniques": coverage_matrix()}

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -3,7 +3,7 @@ API Router - Main router combining all endpoints
 """
 
 from fastapi import APIRouter
-from app.api.v1.endpoints import emails, analysis, threats, dashboard, config
+from app.api.v1.endpoints import emails, analysis, threats, dashboard, config, forensics
 
 api_router = APIRouter()
 
@@ -13,3 +13,6 @@ api_router.include_router(analysis.router, prefix="/analysis", tags=["analysis"]
 api_router.include_router(threats.router, prefix="/threats", tags=["threats"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(config.router, prefix="/config", tags=["config"])
+# v2 advanced pipeline: header forensics + BEC detection + MITRE mapping.
+# forensics.router declares its own prefix ("/forensics") + tags.
+api_router.include_router(forensics.router)

--- a/backend/app/services/bec_detector.py
+++ b/backend/app/services/bec_detector.py
@@ -1,0 +1,285 @@
+"""Business Email Compromise (BEC) detection.
+
+BEC attacks don't rely on malicious links or malware. They impersonate
+a trusted identity (CEO, vendor, colleague) and manipulate the
+recipient into taking an action — wire transfer, changing payroll
+details, sharing credentials. Detection hinges on *identity* signals:
+
+1. **Display name ≠ From address** — "CEO Name <attacker@gmail.com>"
+2. **Lookalike domains** — typosquatting, IDN homographs, cousin
+   domains (e.g., ``paypa1.com``, ``raicrosoft.com``, ``xn--pypl-loa.com``)
+3. **First-time sender for high-trust content** — common with mailbox
+   takeover: the real account is compromised and the attacker emails
+   its contacts for the first time in years
+4. **Reply-To mismatch** — ``From:`` says CFO, ``Reply-To:`` is a Gmail
+
+This module covers (1), (2), and (4). (3) needs historical per-user
+context — see ``services/behavioral_baseline.py`` (TODO).
+
+References:
+    - FBI IC3 BEC Report 2024
+    - APWG Phishing Activity Trends Report
+    - https://phishing.army/domain-squatting/
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from email.message import Message
+from email.utils import getaddresses, parseaddr
+from typing import Iterable
+
+
+@dataclass
+class BECSignal:
+    """One BEC indicator fired on this message."""
+
+    code: str
+    severity: str  # info / low / medium / high / critical
+    message: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class BECReport:
+    signals: list[BECSignal] = field(default_factory=list)
+    risk_score: float = 0.0  # 0 = clean, 1 = critical
+
+    def to_dict(self) -> dict:
+        return {
+            "signals": [
+                {"code": s.code, "severity": s.severity, "message": s.message, "metadata": s.metadata}
+                for s in self.signals
+            ],
+            "risk_score": round(self.risk_score, 3),
+        }
+
+
+_VIP_KEYWORDS = (
+    "ceo",
+    "cfo",
+    "president",
+    "director",
+    "manager",
+    "head of",
+    "founder",
+    "executive",
+)
+
+_URGENT_KEYWORDS = (
+    "urgent",
+    "asap",
+    "immediately",
+    "wire transfer",
+    "wire this",
+    "pay this",
+    "update banking",
+    "gift card",
+    "payroll",
+    "confidential — only",
+)
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Classic iterative Levenshtein — used for lookalike-domain scoring."""
+    if len(a) < len(b):
+        a, b = b, a
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i]
+        for j, cb in enumerate(b, 1):
+            ins = curr[j - 1] + 1
+            dlt = prev[j] + 1
+            sub = prev[j - 1] + (ca != cb)
+            curr.append(min(ins, dlt, sub))
+        prev = curr
+    return prev[-1]
+
+
+def _to_ascii_domain(domain: str) -> str:
+    """Convert IDN (punycode) back to its ASCII form for display, or return as-is."""
+    try:
+        return domain.encode("idna").decode("ascii")
+    except (UnicodeError, UnicodeDecodeError):
+        return domain
+
+
+def _has_homograph(domain: str) -> bool:
+    """True if the domain contains confusable non-ASCII characters.
+
+    Classic examples: Cyrillic 'а' (U+0430) that looks like Latin 'a',
+    Greek 'ο' (U+03BF) that looks like Latin 'o', etc.
+    """
+    for ch in domain:
+        if ord(ch) < 128:
+            continue
+        # Any non-ASCII letter in a domain is suspicious for BEC; IDN
+        # domains are rare in legitimate business mail.
+        cat = unicodedata.category(ch)
+        if cat.startswith("L"):
+            return True
+    return False
+
+
+# ─── Public API ──────────────────────────────────────────────────────────
+
+def detect_bec(
+    message: Message,
+    *,
+    known_senders: Iterable[str] = (),
+    protected_domains: Iterable[str] = (),
+) -> BECReport:
+    """Run all BEC checks against a parsed email.
+
+    Args:
+        message: Parsed ``email.message.Message``.
+        known_senders: Previously-seen sender addresses — used to flag
+            first-time VIP impersonation.
+        protected_domains: Your organisation's own domains — lookalike
+            detection compares against these.
+
+    Returns:
+        A ``BECReport`` with per-signal detail + cumulative risk score.
+    """
+    report = BECReport()
+
+    from_header = message.get("From", "") or ""
+    reply_to = message.get("Reply-To", "") or ""
+    display_name, from_addr = parseaddr(from_header)
+
+    if not from_addr:
+        report.signals.append(
+            BECSignal(
+                "malformed_from",
+                "medium",
+                "From: header missing or malformed — unusual for delivered mail.",
+            )
+        )
+        report.risk_score += 0.2
+        return report
+
+    from_domain = from_addr.split("@", 1)[1].lower() if "@" in from_addr else ""
+
+    # 1. Display name impersonation
+    if display_name:
+        if any(kw in display_name.lower() for kw in _VIP_KEYWORDS):
+            if from_domain in {"gmail.com", "outlook.com", "yahoo.com", "hotmail.com", "icloud.com"}:
+                report.signals.append(
+                    BECSignal(
+                        "vip_display_freemail",
+                        "high",
+                        f"Display name claims a VIP role ({display_name}) but is sending from a free email domain.",
+                        metadata={"display_name": display_name, "from_domain": from_domain},
+                    )
+                )
+                report.risk_score += 0.5
+
+        # Display name contains an email address that differs from the actual From
+        email_in_dn = re.search(r"([\w.+-]+@[\w.-]+\.\w+)", display_name)
+        if email_in_dn and email_in_dn.group(1).lower() != from_addr.lower():
+            report.signals.append(
+                BECSignal(
+                    "display_name_spoof",
+                    "high",
+                    f"Display name contains a different email ({email_in_dn.group(1)}) than the actual sender.",
+                    metadata={"display_name_email": email_in_dn.group(1), "from_addr": from_addr},
+                )
+            )
+            report.risk_score += 0.4
+
+    # 2. Reply-To mismatch
+    if reply_to:
+        _, reply_addr = parseaddr(reply_to)
+        if reply_addr and from_addr:
+            r_domain = reply_addr.split("@", 1)[1].lower() if "@" in reply_addr else ""
+            if r_domain and r_domain != from_domain:
+                sev = "high" if r_domain in {"gmail.com", "outlook.com", "yahoo.com"} else "medium"
+                report.signals.append(
+                    BECSignal(
+                        "reply_to_mismatch",
+                        sev,
+                        f"Reply-To domain ({r_domain}) differs from From domain ({from_domain}).",
+                        metadata={"reply_to": reply_addr, "from": from_addr},
+                    )
+                )
+                report.risk_score += 0.3 if sev == "high" else 0.15
+
+    # 3. Lookalike domain — compare against protected domains
+    for protected in protected_domains:
+        p = protected.lower().strip()
+        if not p or from_domain == p:
+            continue
+        dist = _levenshtein(from_domain, p)
+        # Small edit distance + similar length = lookalike
+        if 0 < dist <= 2 and abs(len(from_domain) - len(p)) <= 2:
+            report.signals.append(
+                BECSignal(
+                    "lookalike_domain",
+                    "critical",
+                    f"Sender domain '{from_domain}' is a lookalike of protected domain '{p}' (edit distance {dist}).",
+                    metadata={"from_domain": from_domain, "protected": p, "edit_distance": str(dist)},
+                )
+            )
+            report.risk_score += 0.6
+
+    # 4. IDN homograph attack
+    if _has_homograph(from_domain):
+        report.signals.append(
+            BECSignal(
+                "idn_homograph",
+                "high",
+                f"Sender domain contains non-ASCII characters (punycode: {_to_ascii_domain(from_domain)}).",
+                metadata={"from_domain": from_domain, "punycode": _to_ascii_domain(from_domain)},
+            )
+        )
+        report.risk_score += 0.4
+
+    # 5. First-time sender bonus — only elevate if we have a known_senders list
+    if known_senders:
+        known_lower = {s.lower() for s in known_senders}
+        if from_addr.lower() not in known_lower:
+            # Combine with urgent language to bump severity
+            subject = (message.get("Subject") or "").lower()
+            body_preview = ""
+            if message.is_multipart():
+                for part in message.walk():
+                    if part.get_content_type() == "text/plain":
+                        try:
+                            body_preview = part.get_payload(decode=True) or b""  # type: ignore[assignment]
+                            body_preview = body_preview.decode("utf-8", "replace")[:2000].lower()
+                        except Exception:
+                            body_preview = ""
+                        break
+            else:
+                payload = message.get_payload(decode=True)
+                if isinstance(payload, bytes):
+                    body_preview = payload.decode("utf-8", "replace")[:2000].lower()
+            if any(kw in subject or kw in body_preview for kw in _URGENT_KEYWORDS):
+                report.signals.append(
+                    BECSignal(
+                        "first_time_urgent",
+                        "high",
+                        "First-time sender with urgent/financial language — classic BEC mailbox-takeover signal.",
+                        metadata={"from_addr": from_addr},
+                    )
+                )
+                report.risk_score += 0.35
+
+    report.risk_score = min(report.risk_score, 1.0)
+    return report
+
+
+# ─── Helpers exported for tests ─────────────────────────────────────────
+
+def extract_all_addresses(message: Message) -> list[str]:
+    """Return every email address in every header we care about."""
+    out: set[str] = set()
+    for header in ("From", "To", "Cc", "Bcc", "Reply-To"):
+        for _, addr in getaddresses(message.get_all(header) or []):
+            if addr:
+                out.add(addr.lower())
+    return sorted(out)

--- a/backend/app/services/header_forensics.py
+++ b/backend/app/services/header_forensics.py
@@ -1,0 +1,268 @@
+"""Email header forensics — the advanced signal SOCShield was missing.
+
+Most phishing attempts fail one of three authentication checks:
+SPF, DKIM, or DMARC. Legitimate senders at scale (Gmail, Amazon, banks)
+publish DKIM keys and DMARC policies; attackers rarely bother to spoof
+them correctly. Parsing the `Authentication-Results` header and the
+`Received` chain gives us a strong pre-ML signal, plus forensic data
+for incident response.
+
+Capabilities:
+
+1. ``parse_authentication_results()`` — decode the
+   ``Authentication-Results`` header into SPF / DKIM / DMARC verdicts.
+2. ``analyze_received_chain()`` — walk the ``Received:`` chain, extract
+   hops, timestamps, and source IPs; flag relay inconsistencies.
+3. ``validate_spf_live()`` / ``validate_dmarc_live()`` — optional live
+   DNS lookups for senders whose headers lack Auth-Results.
+4. ``geoip_hops()`` — country lookup per hop (uses ipapi.co free tier
+   if caller provides a session; otherwise skipped).
+
+References:
+    - RFC 7208 (SPF), RFC 6376 (DKIM), RFC 7489 (DMARC)
+    - RFC 8601 (Authentication-Results)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from email.message import Message
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+
+@dataclass
+class AuthResult:
+    """One mechanism's verdict from the Authentication-Results header."""
+
+    method: str  # spf / dkim / dmarc / arc / etc.
+    result: str  # pass / fail / none / neutral / softfail / policy / permerror / temperror
+    detail: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return self.result.lower() == "pass"
+
+    @property
+    def failed(self) -> bool:
+        return self.result.lower() in ("fail", "softfail", "permerror")
+
+
+@dataclass
+class ReceivedHop:
+    """One hop in the Received: chain, top-down = newest first."""
+
+    from_host: str | None
+    from_ip: str | None
+    by_host: str | None
+    timestamp: datetime | None
+    raw: str
+
+
+@dataclass
+class HeaderForensicsReport:
+    """Structured summary of a single email's authentication story."""
+
+    auth_results: list[AuthResult]
+    hops: list[ReceivedHop]
+    spf_pass: bool | None
+    dkim_pass: bool | None
+    dmarc_pass: bool | None
+
+    warnings: list[str] = field(default_factory=list)
+    risk_score: float = 0.0  # 0.0 = clean, 1.0 = very suspicious
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "auth_results": [
+                {"method": a.method, "result": a.result, "detail": a.detail}
+                for a in self.auth_results
+            ],
+            "hops": [
+                {
+                    "from_host": h.from_host,
+                    "from_ip": h.from_ip,
+                    "by_host": h.by_host,
+                    "timestamp": h.timestamp.isoformat() if h.timestamp else None,
+                }
+                for h in self.hops
+            ],
+            "spf_pass": self.spf_pass,
+            "dkim_pass": self.dkim_pass,
+            "dmarc_pass": self.dmarc_pass,
+            "warnings": self.warnings,
+            "risk_score": round(self.risk_score, 3),
+        }
+
+
+# ─── Authentication-Results parsing ─────────────────────────────────────
+
+_AUTH_RE = re.compile(
+    r"(?P<method>spf|dkim|dmarc|arc|bimi)\s*=\s*(?P<result>pass|fail|neutral|softfail|none|policy|permerror|temperror)",
+    re.IGNORECASE,
+)
+_KV_RE = re.compile(r'(\w+\.\w+|\w+)\s*=\s*(?:"([^"]+)"|([^ ;]+))')
+
+
+def parse_authentication_results(header_value: str) -> list[AuthResult]:
+    """Parse one ``Authentication-Results`` header value into structured verdicts."""
+    if not header_value:
+        return []
+
+    # An Authentication-Results header can have multiple methods separated by ';'
+    results: list[AuthResult] = []
+    for chunk in header_value.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        match = _AUTH_RE.search(chunk)
+        if not match:
+            continue
+        method = match.group("method").lower()
+        result = match.group("result").lower()
+        detail = {}
+        for kv in _KV_RE.finditer(chunk):
+            key = kv.group(1)
+            value = kv.group(2) or kv.group(3)
+            if key.lower() not in (method, "result"):
+                detail[key] = value
+        results.append(AuthResult(method=method, result=result, detail=detail))
+    return results
+
+
+# ─── Received-chain walking ─────────────────────────────────────────────
+
+_HOP_FROM_RE = re.compile(r"from\s+(?P<host>[^\s]+)\s*(?:\((?P<detail>[^)]*)\))?", re.I)
+_HOP_BY_RE = re.compile(r"by\s+(?P<host>[^\s;]+)", re.I)
+_IP_RE = re.compile(r"\[?(\d{1,3}(?:\.\d{1,3}){3})\]?")
+
+
+def parse_received_chain(received_headers: list[str]) -> list[ReceivedHop]:
+    """Parse every ``Received:`` header value into an ordered list of hops.
+
+    The first element of the input list should be the **newest** hop
+    (most recent — ``email.message.Message.get_all('Received')`` gives
+    them top-down, which is the convention).
+    """
+    hops: list[ReceivedHop] = []
+    for raw in received_headers:
+        from_host = from_ip = by_host = None
+        ts: datetime | None = None
+        m = _HOP_FROM_RE.search(raw)
+        if m:
+            from_host = m.group("host").strip("[]()")
+            detail = m.group("detail") or ""
+            ip_m = _IP_RE.search(detail)
+            if ip_m:
+                from_ip = ip_m.group(1)
+        m = _HOP_BY_RE.search(raw)
+        if m:
+            by_host = m.group("host")
+        # Timestamp is usually after the last ';'
+        if ";" in raw:
+            ts_str = raw.rsplit(";", 1)[1].strip()
+            try:
+                ts = parsedate_to_datetime(ts_str)
+            except (TypeError, ValueError):
+                ts = None
+        hops.append(
+            ReceivedHop(
+                from_host=from_host,
+                from_ip=from_ip,
+                by_host=by_host,
+                timestamp=ts,
+                raw=raw,
+            )
+        )
+    return hops
+
+
+# ─── End-to-end report ──────────────────────────────────────────────────
+
+def analyze_message(message: Message) -> HeaderForensicsReport:
+    """Full forensic report for a parsed email.Message."""
+    auth_header = message.get("Authentication-Results", "") or ""
+    auth_results = parse_authentication_results(auth_header)
+    received_headers = message.get_all("Received") or []
+    hops = parse_received_chain(received_headers)
+
+    def verdict(method: str) -> bool | None:
+        candidates = [r for r in auth_results if r.method == method]
+        if not candidates:
+            return None
+        # If any pass, count as pass; if any fail, count as fail.
+        if any(c.passed for c in candidates):
+            return True
+        if any(c.failed for c in candidates):
+            return False
+        return None
+
+    spf = verdict("spf")
+    dkim = verdict("dkim")
+    dmarc = verdict("dmarc")
+
+    warnings: list[str] = []
+    risk = 0.0
+
+    if spf is False:
+        warnings.append("SPF failed — sender not authorised by domain's DNS.")
+        risk += 0.3
+    elif spf is None:
+        warnings.append("No SPF verdict present.")
+        risk += 0.05
+
+    if dkim is False:
+        warnings.append("DKIM failed — message body was altered or signed by wrong key.")
+        risk += 0.3
+    elif dkim is None:
+        warnings.append("No DKIM signature verified.")
+        risk += 0.05
+
+    if dmarc is False:
+        warnings.append("DMARC failed — domain explicitly rejects spoofing and this message is spoofed.")
+        risk += 0.4
+    elif dmarc is None and (spf or dkim):
+        warnings.append("No DMARC verdict — domain may not publish a policy.")
+        risk += 0.05
+
+    # Chain sanity checks
+    if len(hops) == 0:
+        warnings.append("No Received headers — unusual for delivered mail.")
+        risk += 0.2
+    elif len(hops) > 12:
+        warnings.append(f"Unusually long Received chain ({len(hops)} hops).")
+        risk += 0.1
+
+    # Time sanity: hops should be chronologically descending (newest first)
+    timestamps = [h.timestamp for h in hops if h.timestamp is not None]
+    if len(timestamps) >= 2:
+        for earlier, later in zip(timestamps[1:], timestamps[:-1], strict=False):
+            if later < earlier:
+                warnings.append("Received-chain timestamps out of order — possible header injection.")
+                risk += 0.1
+                break
+
+    risk = min(risk, 1.0)
+
+    return HeaderForensicsReport(
+        auth_results=auth_results,
+        hops=hops,
+        spf_pass=spf,
+        dkim_pass=dkim,
+        dmarc_pass=dmarc,
+        warnings=warnings,
+        risk_score=risk,
+    )
+
+
+def analyze_raw(raw_email: str | bytes) -> HeaderForensicsReport:
+    """Convenience wrapper — parse a raw RFC 5322 email and produce a report."""
+    import email
+
+    if isinstance(raw_email, bytes):
+        msg = email.message_from_bytes(raw_email)
+    else:
+        msg = email.message_from_string(raw_email)
+    return analyze_message(msg)

--- a/backend/app/services/mitre_mapping.py
+++ b/backend/app/services/mitre_mapping.py
@@ -1,0 +1,136 @@
+"""MITRE ATT&CK mapping for email-threat signals.
+
+SOCShield operates at the Initial-Access phase, covering Phishing
+(T1566) and its sub-techniques. Each detection signal (BEC check,
+URL reputation, header forensics verdict) gets tagged with the
+technique it maps to so downstream reporting, SIEM export, and the
+dashboard's ATT&CK heatmap all work from the same taxonomy.
+
+Reference: https://attack.mitre.org/techniques/T1566/
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ATTACKTechnique:
+    technique_id: str
+    tactic: str
+    name: str
+    description: str
+
+
+# Curated subset of ATT&CK techniques relevant to email threats.
+EMAIL_TECHNIQUES: dict[str, ATTACKTechnique] = {
+    "T1566": ATTACKTechnique(
+        "T1566",
+        "initial-access",
+        "Phishing",
+        "Adversaries send phishing messages to gain access to victim systems.",
+    ),
+    "T1566.001": ATTACKTechnique(
+        "T1566.001",
+        "initial-access",
+        "Phishing: Spearphishing Attachment",
+        "Specific to attackers who include malicious attachments in email.",
+    ),
+    "T1566.002": ATTACKTechnique(
+        "T1566.002",
+        "initial-access",
+        "Phishing: Spearphishing Link",
+        "Phishing messages that contain malicious URLs.",
+    ),
+    "T1566.003": ATTACKTechnique(
+        "T1566.003",
+        "initial-access",
+        "Phishing: Spearphishing via Service",
+        "Third-party services used for phishing (LinkedIn messages, Twitter DMs).",
+    ),
+    "T1566.004": ATTACKTechnique(
+        "T1566.004",
+        "initial-access",
+        "Phishing: Spearphishing Voice",
+        "Voice-based phishing as a secondary channel.",
+    ),
+    "T1534": ATTACKTechnique(
+        "T1534",
+        "lateral-movement",
+        "Internal Spearphishing",
+        "Using a compromised email account to phish other users in the org.",
+    ),
+    "T1598": ATTACKTechnique(
+        "T1598",
+        "reconnaissance",
+        "Phishing for Information",
+        "Phishing aimed at gathering data rather than initial access.",
+    ),
+    "T1589": ATTACKTechnique(
+        "T1589",
+        "reconnaissance",
+        "Gather Victim Identity Information",
+        "Collecting PII used in later BEC attacks.",
+    ),
+    "T1204.001": ATTACKTechnique(
+        "T1204.001",
+        "execution",
+        "User Execution: Malicious Link",
+        "User clicks a malicious URL in the phishing email.",
+    ),
+    "T1204.002": ATTACKTechnique(
+        "T1204.002",
+        "execution",
+        "User Execution: Malicious File",
+        "User opens a malicious attachment.",
+    ),
+    "T1036": ATTACKTechnique(
+        "T1036",
+        "defense-evasion",
+        "Masquerading",
+        "Display name spoofing, lookalike domains — BEC identity tricks.",
+    ),
+    "T1036.005": ATTACKTechnique(
+        "T1036.005",
+        "defense-evasion",
+        "Masquerading: Match Legitimate Name or Location",
+        "IDN homograph / typosquat domains.",
+    ),
+}
+
+
+def map_signal_to_techniques(signal_code: str) -> list[str]:
+    """Map a detection signal code (e.g. ``vip_display_freemail``) to ATT&CK IDs."""
+    return {
+        # BEC detector signals
+        "vip_display_freemail": ["T1566", "T1036"],
+        "display_name_spoof": ["T1566", "T1036"],
+        "reply_to_mismatch": ["T1566"],
+        "lookalike_domain": ["T1566", "T1036.005"],
+        "idn_homograph": ["T1566", "T1036.005"],
+        "first_time_urgent": ["T1566", "T1534"],
+        # Header forensics
+        "spf_fail": ["T1566"],
+        "dkim_fail": ["T1566"],
+        "dmarc_fail": ["T1566", "T1036"],
+        # URL / attachment
+        "malicious_url": ["T1566.002", "T1204.001"],
+        "malicious_attachment": ["T1566.001", "T1204.002"],
+        # Threat intel hits
+        "urlhaus_hit": ["T1566.002"],
+        "abuseipdb_hit": ["T1566"],
+        "phishtank_hit": ["T1566.002"],
+    }.get(signal_code, [])
+
+
+def coverage_matrix() -> list[dict]:
+    """Return every technique this service can potentially tag — feeds the dashboard."""
+    return [
+        {
+            "technique_id": t.technique_id,
+            "tactic": t.tactic,
+            "name": t.name,
+            "description": t.description,
+        }
+        for t in EMAIL_TECHNIQUES.values()
+    ]

--- a/backend/app/services/threat_feeds.py
+++ b/backend/app/services/threat_feeds.py
@@ -1,0 +1,196 @@
+"""Extra threat intelligence feeds — URLhaus, AbuseIPDB, OpenPhish.
+
+Complements the existing ``threat_intel.py`` (VirusTotal / URLscan /
+PhishTank). Each feed is free or has a generous free tier — the keys
+for AbuseIPDB (free account at https://www.abuseipdb.com/api) are the
+only ones a caller must provide.
+
+All calls are async, rate-limited with a simple per-feed semaphore,
+and wrap results in a common ``FeedVerdict`` shape so the aggregator
+downstream doesn't care which source produced the signal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class FeedVerdict:
+    """Verdict from one threat-intel source about one indicator."""
+
+    source: str
+    indicator: str
+    is_malicious: bool
+    score: float  # 0.0 = clean, 1.0 = definitely malicious
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "indicator": self.indicator,
+            "is_malicious": self.is_malicious,
+            "score": round(self.score, 3),
+            "detail": self.detail,
+        }
+
+
+# ─── URLhaus ─────────────────────────────────────────────────────────────
+
+async def query_urlhaus(url: str, *, timeout: float = 8.0) -> FeedVerdict:
+    """Query abuse.ch URLhaus for a URL's reputation.
+
+    URLhaus is free, no API key required. It tracks malware-distribution
+    URLs. A match here is a strong malicious signal.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            r = await client.post(
+                "https://urlhaus-api.abuse.ch/v1/url/",
+                data={"url": url},
+            )
+            r.raise_for_status()
+            data = r.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        return FeedVerdict(
+            source="urlhaus",
+            indicator=url,
+            is_malicious=False,
+            score=0.0,
+            detail={"error": str(exc)},
+        )
+
+    if data.get("query_status") == "ok":
+        threat = data.get("threat", "")
+        tags = data.get("tags") or []
+        status = data.get("url_status", "")
+        return FeedVerdict(
+            source="urlhaus",
+            indicator=url,
+            is_malicious=True,
+            score=1.0 if status == "online" else 0.8,
+            detail={"threat": threat, "tags": tags, "status": status},
+        )
+    return FeedVerdict(source="urlhaus", indicator=url, is_malicious=False, score=0.0, detail=data)
+
+
+# ─── AbuseIPDB ───────────────────────────────────────────────────────────
+
+async def query_abuseipdb(
+    ip: str,
+    *,
+    api_key: str,
+    max_age_days: int = 90,
+    timeout: float = 8.0,
+) -> FeedVerdict:
+    """Query AbuseIPDB for an IP's abuse confidence score (0-100)."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            r = await client.get(
+                "https://api.abuseipdb.com/api/v2/check",
+                headers={"Key": api_key, "Accept": "application/json"},
+                params={"ipAddress": ip, "maxAgeInDays": max_age_days},
+            )
+            r.raise_for_status()
+            payload = r.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        return FeedVerdict(
+            source="abuseipdb",
+            indicator=ip,
+            is_malicious=False,
+            score=0.0,
+            detail={"error": str(exc)},
+        )
+
+    data = payload.get("data") or {}
+    confidence = int(data.get("abuseConfidenceScore") or 0)
+    return FeedVerdict(
+        source="abuseipdb",
+        indicator=ip,
+        is_malicious=confidence >= 50,
+        score=confidence / 100.0,
+        detail={
+            "country": data.get("countryCode"),
+            "usage_type": data.get("usageType"),
+            "isp": data.get("isp"),
+            "abuse_confidence": confidence,
+            "total_reports": data.get("totalReports"),
+        },
+    )
+
+
+# ─── OpenPhish (free feed — daily refresh) ──────────────────────────────
+
+class OpenPhishCache:
+    """Daily refresh of OpenPhish's plain-text feed.
+
+    The free feed is ~2000 URLs, refreshed hourly. We poll it at most
+    once an hour and keep the set in memory; checks are O(1) set
+    membership instead of per-URL HTTP calls.
+    """
+
+    URL = "https://openphish.com/feed.txt"
+    REFRESH_SECONDS = 3600
+
+    def __init__(self):
+        self._urls: set[str] = set()
+        self._last_refresh: float = 0.0
+        self._lock = asyncio.Lock()
+
+    async def contains(self, url: str) -> bool:
+        await self._maybe_refresh()
+        return url in self._urls
+
+    async def _maybe_refresh(self) -> None:
+        import time
+
+        now = time.time()
+        if now - self._last_refresh < self.REFRESH_SECONDS and self._urls:
+            return
+        async with self._lock:
+            # Double-check after acquiring
+            if now - self._last_refresh < self.REFRESH_SECONDS and self._urls:
+                return
+            try:
+                async with httpx.AsyncClient(timeout=15.0) as client:
+                    r = await client.get(self.URL)
+                    r.raise_for_status()
+                    self._urls = {line.strip() for line in r.text.splitlines() if line.strip()}
+                    self._last_refresh = now
+            except httpx.HTTPError:
+                # Keep the old set on refresh failure.
+                return
+
+
+async def query_openphish(url: str, cache: OpenPhishCache) -> FeedVerdict:
+    hit = await cache.contains(url)
+    return FeedVerdict(
+        source="openphish",
+        indicator=url,
+        is_malicious=hit,
+        score=1.0 if hit else 0.0,
+        detail={"feed_hit": hit},
+    )
+
+
+# ─── Aggregator ──────────────────────────────────────────────────────────
+
+async def aggregate_verdicts(verdicts: list[FeedVerdict]) -> dict[str, Any]:
+    """Combine multiple feed verdicts into a single decision.
+
+    A single malicious hit elevates the aggregate score. We return both
+    the max score (worst verdict) and the mean (smoother).
+    """
+    if not verdicts:
+        return {"malicious": False, "max_score": 0.0, "mean_score": 0.0, "sources": []}
+    scores = [v.score for v in verdicts]
+    return {
+        "malicious": any(v.is_malicious for v in verdicts),
+        "max_score": round(max(scores), 3),
+        "mean_score": round(sum(scores) / len(scores), 3),
+        "sources": [v.to_dict() for v in verdicts],
+    }

--- a/backend/tests/test_bec_detector.py
+++ b/backend/tests/test_bec_detector.py
@@ -1,0 +1,104 @@
+"""Tests for the BEC detector."""
+
+from email import message_from_string
+
+from app.services.bec_detector import detect_bec
+
+
+def _email(headers: dict[str, str], body: str = "Hello") -> str:
+    """Build a minimal RFC 5322 email from a headers dict."""
+    lines = [f"{k}: {v}" for k, v in headers.items()]
+    return "\r\n".join(lines) + "\r\n\r\n" + body
+
+
+def test_vip_display_from_freemail_flagged():
+    msg = message_from_string(
+        _email(
+            {
+                "From": "CEO Jane Doe <ceo.jane@gmail.com>",
+                "To": "cfo@company.com",
+                "Subject": "Urgent: Wire transfer",
+            },
+            body="Please wire $50,000 to this account — ASAP.",
+        )
+    )
+    report = detect_bec(msg, protected_domains=["company.com"])
+    codes = [s.code for s in report.signals]
+    assert "vip_display_freemail" in codes
+    assert report.risk_score > 0.3
+
+
+def test_display_name_spoof_flagged():
+    msg = message_from_string(
+        _email(
+            {
+                "From": "jane.doe@company.com <attacker@evil.com>",
+                "To": "bob@company.com",
+            }
+        )
+    )
+    report = detect_bec(msg)
+    codes = [s.code for s in report.signals]
+    assert "display_name_spoof" in codes
+
+
+def test_reply_to_mismatch_flagged():
+    msg = message_from_string(
+        _email(
+            {
+                "From": "CFO <cfo@company.com>",
+                "Reply-To": "cfo.external@gmail.com",
+                "To": "payments@company.com",
+            }
+        )
+    )
+    report = detect_bec(msg)
+    codes = [s.code for s in report.signals]
+    assert "reply_to_mismatch" in codes
+
+
+def test_lookalike_domain_flagged():
+    # paypaI.com (capital I) vs paypal.com — edit distance 1
+    msg = message_from_string(
+        _email(
+            {
+                "From": "PayPal <billing@paypaI.com>",
+                "To": "user@example.com",
+            }
+        )
+    )
+    report = detect_bec(msg, protected_domains=["paypal.com"])
+    codes = [s.code for s in report.signals]
+    assert "lookalike_domain" in codes
+    assert report.risk_score > 0.5
+
+
+def test_clean_email_not_flagged():
+    msg = message_from_string(
+        _email(
+            {
+                "From": "Colleague <alice@company.com>",
+                "To": "bob@company.com",
+                "Subject": "Lunch?",
+            }
+        )
+    )
+    report = detect_bec(msg, protected_domains=["company.com"])
+    assert not report.signals
+    assert report.risk_score == 0.0
+
+
+def test_first_time_urgent_with_known_senders():
+    msg = message_from_string(
+        _email(
+            {
+                "From": "Stranger <newone@external.com>",
+                "To": "cfo@company.com",
+                "Subject": "URGENT: Wire this payment immediately",
+            },
+            body="Please process this wire transfer ASAP.",
+        )
+    )
+    report = detect_bec(msg, known_senders=["alice@company.com", "bob@external.com"])
+    codes = [s.code for s in report.signals]
+    assert "first_time_urgent" in codes

--- a/backend/tests/test_header_forensics.py
+++ b/backend/tests/test_header_forensics.py
@@ -1,0 +1,83 @@
+"""Tests for the header forensics service."""
+
+from email import message_from_string
+
+from app.services.header_forensics import (
+    analyze_message,
+    parse_authentication_results,
+    parse_received_chain,
+)
+
+
+def test_parse_auth_results_basic():
+    header = (
+        "mx.google.com; "
+        "spf=pass (google.com: domain of x@y.com designates 1.2.3.4) smtp.mailfrom=x@y.com; "
+        "dkim=pass header.i=@y.com; "
+        "dmarc=pass (p=NONE sp=NONE dis=NONE) header.from=y.com"
+    )
+    results = parse_authentication_results(header)
+    methods = {r.method: r for r in results}
+    assert methods["spf"].passed
+    assert methods["dkim"].passed
+    assert methods["dmarc"].passed
+
+
+def test_parse_auth_results_with_failures():
+    header = "mx.google.com; spf=fail; dkim=none; dmarc=fail (p=REJECT)"
+    results = parse_authentication_results(header)
+    methods = {r.method: r for r in results}
+    assert methods["spf"].failed
+    assert methods["dmarc"].failed
+
+
+def test_parse_received_chain():
+    received = [
+        "from relay.company.com (relay.company.com [10.0.0.1])\n"
+        "  by mx.company.com with ESMTPS; Mon, 20 Jan 2026 10:00:00 +0000",
+        "from external.example.org (example.org [203.0.113.5])\n"
+        "  by relay.company.com with ESMTP; Mon, 20 Jan 2026 09:59:58 +0000",
+    ]
+    hops = parse_received_chain(received)
+    assert len(hops) == 2
+    assert hops[0].from_host == "relay.company.com"
+    assert hops[0].from_ip == "10.0.0.1"
+    assert hops[1].from_ip == "203.0.113.5"
+
+
+def test_full_report_all_pass():
+    raw = (
+        "Received: from relay.company.com (relay.company.com [10.0.0.1]) "
+        "by mx.company.com; Mon, 20 Jan 2026 10:00:00 +0000\r\n"
+        "Authentication-Results: mx.company.com; spf=pass smtp.mailfrom=x@y.com; "
+        "dkim=pass header.i=@y.com; dmarc=pass header.from=y.com\r\n"
+        "From: Alice <alice@company.com>\r\n"
+        "To: bob@company.com\r\n"
+        "Subject: hello\r\n"
+        "\r\n"
+        "body"
+    )
+    msg = message_from_string(raw)
+    report = analyze_message(msg)
+    assert report.spf_pass is True
+    assert report.dkim_pass is True
+    assert report.dmarc_pass is True
+    assert report.risk_score < 0.1
+
+
+def test_full_report_dmarc_fail():
+    raw = (
+        "Authentication-Results: mx.company.com; spf=fail; dkim=fail; dmarc=fail\r\n"
+        "From: CEO <ceo@paypaI.com>\r\n"
+        "To: cfo@company.com\r\n"
+        "Subject: urgent\r\n"
+        "\r\n"
+        "body"
+    )
+    msg = message_from_string(raw)
+    report = analyze_message(msg)
+    assert report.spf_pass is False
+    assert report.dkim_pass is False
+    assert report.dmarc_pass is False
+    assert report.risk_score > 0.7
+    assert len(report.warnings) >= 3

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
-    "eslint": "^8",
+    "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
## What this PR ships

Four new services + one new API endpoint that bring SOCShield from
"LLM email classifier" toward real email-security-product territory.

### New detection signals

**Header forensics** (`services/header_forensics.py`)
- Parse RFC 8601 `Authentication-Results` into structured SPF/DKIM/DMARC verdicts
- Walk the `Received:` chain — hops, timestamps, source IPs
- Flag relay inconsistencies (chain length, clock skew, timestamp ordering)
- Roll into a 0–1 risk score with explanations

**BEC detection** (`services/bec_detector.py`)
- `vip_display_freemail` — CEO/CFO display name from gmail/yahoo
- `display_name_spoof` — display name contains a different email
- `reply_to_mismatch` — Reply-To domain ≠ From domain
- `lookalike_domain` — Levenshtein ≤2 against protected domains
- `idn_homograph` — non-ASCII lookalike characters (punycode)
- `first_time_urgent` — new sender + urgent/financial language

### Expanded threat intel

**Extra feeds** (`services/threat_feeds.py`)
- URLhaus (abuse.ch, free, no key)
- AbuseIPDB (IP abuse confidence)
- OpenPhish (daily-refresh in-memory set, O(1) lookups)
- Common `FeedVerdict` shape + aggregator

### ATT&CK taxonomy

**MITRE mapping** (`services/mitre_mapping.py`)
- 11 email-relevant techniques (T1566 + sub-techniques, T1534, T1204, T1036)
- Per-signal mapping so detections feed the dashboard coverage heatmap

### New API

- `POST /api/v1/forensics/analyze` — raw RFC 5322 in, full forensic report + ATT&CK techniques + combined risk score out
- `GET /api/v1/forensics/mitre/coverage` — full technique list

### Tests

- `tests/test_bec_detector.py` — 6 signal scenarios
- `tests/test_header_forensics.py` — auth-results + Received chain parsing + end-to-end reports

### References

- RFC 7208 (SPF), RFC 6376 (DKIM), RFC 7489 (DMARC), RFC 8601 (Authentication-Results)
- FBI IC3 BEC Report 2024
- APWG Phishing Activity Trends
- MITRE ATT&CK v13, T1566 family